### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Platform | Description
 
 ## Prerequisites
 - You need to have a notion account and a notion integration token. You can get one by following the instructions [here](https://developers.notion.com/docs/getting-started).
-- You need to create a database from the Notion´s official ToDo template. You can find it [here](https://www.notion.so/Notion-To-Do-List-Template-0b2e2d8980b74c5e8e8c1e6c0f8b4b4e).
+- You need to create a database from the Notion´s official ToDo template. You can find it [here]((https://www.notion.so/4b5de264413546a384e1dadb6c4ce2cf?duplicate=true&from=notion_template_gallery)).
 - You need to share the database with the integration token you created before.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Platform | Description
 
 ## Prerequisites
 - You need to have a notion account and a notion integration token. You can get one by following the instructions [here](https://developers.notion.com/docs/getting-started).
-- You need to create a database from the Notion´s official ToDo template. You can find it [here](https://www.notion.so/4b5de264413546a384e1dadb6c4ce2cf?duplicate=true&from=notion_template_gallery).
+- You need to create a database from the Notion´s official ToDo template. You can find it [here](https://www.notion.so/templates/to-do-list).
 - You need to share the database with the integration token you created before.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Platform | Description
 
 ## Prerequisites
 - You need to have a notion account and a notion integration token. You can get one by following the instructions [here](https://developers.notion.com/docs/getting-started).
-- You need to create a database from the Notion´s official ToDo template. You can find it [here]((https://www.notion.so/4b5de264413546a384e1dadb6c4ce2cf?duplicate=true&from=notion_template_gallery)).
+- You need to create a database from the Notion´s official ToDo template. You can find it [here](https://www.notion.so/4b5de264413546a384e1dadb6c4ce2cf?duplicate=true&from=notion_template_gallery).
 - You need to share the database with the integration token you created before.
 
 ## Installation


### PR DESCRIPTION
Hello! I noticed that the notion template link in your README is broken and just goes to a 404 not found, so I figured I would create a pull request to fix it.

If this isn't the correct link please let me know and I'll try to find the right replacement.